### PR TITLE
Keep original style when substituting in captured groups.

### DIFF
--- a/common/src/main/java/dev/terminalmc/chatnotify/util/MessageUtil.java
+++ b/common/src/main/java/dev/terminalmc/chatnotify/util/MessageUtil.java
@@ -280,7 +280,7 @@ public class MessageUtil {
 
                 // If replacement enabled, process
                 if (notif.replacementMsgEnabled) {
-                    msg = convertMsg(notif.replacementMsg, subsMatcher);
+                    msg = convertMsg(notif.replacementMsg, subsMatcher, msg);
                     String str = msg.getString();
                     cleanStr = FormatUtil.stripCodes(str);
                     cleanOwnedStr = cleanStr;
@@ -356,21 +356,64 @@ public class MessageUtil {
 
     /**
      * Converts a custom message string into a {@link Component} for sending.
-     * @param msg the custom message string.
+     * @param msgString the custom message string.
      * @param matcher a regex matcher for capturing group substitution.
+     * @param msg the original message.
      * @return the message, converted and with all substitutions done.
      */
-    private static Component convertMsg(String msg, @Nullable Matcher matcher) {
+    private static Component convertMsg(String msgString, @Nullable Matcher matcher, Component msg) {
         // Replace $ with section sign
-        msg = msg.replaceAll(Matcher.quoteReplacement("$"), "§");
+        msgString = msgString.replaceAll(Matcher.quoteReplacement("$"), "§");
+
         // Substitute capturing groups
         if (matcher != null && matcher.find(0)) {
-            for (int i = 0; i <= matcher.groupCount(); i++) {
-                String replacement = matcher.group(i) == null ? "" : matcher.group(i);
-                msg = msg.replaceAll("\\(" + i + "\\)", replacement);
+
+            // Record indexes where groups should be placed,
+            // and make Components for each group.
+            ArrayList<int[]> indexesToReplaceWithGroups = new ArrayList<>();
+            HashMap<Integer, Component> replacementComponents = new HashMap<>();
+            for (int groupNum = 0; groupNum <= matcher.groupCount(); groupNum++) {
+                String targetString = "(" + groupNum + ")";
+                if (!msgString.contains(targetString)) continue;
+
+                // Record indexes to replace with group
+                int index = msgString.indexOf(targetString);
+                while (index >= 0) {
+                    indexesToReplaceWithGroups.add(new int[]{index, groupNum });
+                    index = msgString.indexOf(targetString, index + targetString.length());
+                }
+
+                Component replacement;
+                if (matcher.group(groupNum) == null) {
+                    replacement = Component.empty();
+                } else {
+                    int start = matcher.start(groupNum);
+                    int end = matcher.end(groupNum);
+                    replacement = StyleUtil.substringKeepStyle(msg, start, end);
+                }
+                replacementComponents.put(groupNum, replacement);
+            }
+
+            // Sort replacements by order that they appear in the text
+            indexesToReplaceWithGroups.sort(Comparator.comparingInt(obj -> obj[0]));
+
+            // Build the new msg, placing in the group Components where appropriate.
+            if (!indexesToReplaceWithGroups.isEmpty()) {
+                MutableComponent newMsg = Component.empty();
+                int startIndex = 0;
+                for (int[] replacement : indexesToReplaceWithGroups) {
+                    System.out.println(newMsg);
+                    newMsg.append(Component.literal(
+                            msgString.substring(startIndex, replacement[0])));
+                    newMsg.append(replacementComponents.get(replacement[1]));
+                    startIndex = replacement[0] + ("(" + replacement[1] + ")").length();
+                }
+                newMsg.append(Component.literal(
+                        msgString.substring(startIndex)));
+                return newMsg;
             }
         }
-        return Component.literal(msg);
+        return Component.literal(msgString);
     }
 
     /**
@@ -384,7 +427,7 @@ public class MessageUtil {
         if (notif.statusBarMsgEnabled) {
             Component displayMsg = notif.statusBarMsg.isBlank()
                     ? msg
-                    : convertMsg(notif.statusBarMsg, matcher);
+                    : convertMsg(notif.statusBarMsg, matcher, msg);
             Minecraft.getInstance().gui.setOverlayMessage(displayMsg, false);
         }
     }
@@ -400,7 +443,7 @@ public class MessageUtil {
         if (notif.titleMsgEnabled) {
             Component displayMsg = notif.titleMsg.isBlank()
                     ? msg
-                    : convertMsg(notif.titleMsg, matcher);
+                    : convertMsg(notif.titleMsg, matcher, msg);
             Minecraft.getInstance().gui.setTitle(displayMsg);
         }
     }
@@ -416,7 +459,7 @@ public class MessageUtil {
         if (notif.toastMsgEnabled) {
             Component displayMsg = notif.toastMsg.isBlank()
                     ? msg
-                    : convertMsg(notif.toastMsg, matcher);
+                    : convertMsg(notif.toastMsg, matcher, msg);
             Minecraft.getInstance().getToasts().addToast(new NotificationToast(displayMsg));
         }
     }

--- a/common/src/main/java/dev/terminalmc/chatnotify/util/MessageUtil.java
+++ b/common/src/main/java/dev/terminalmc/chatnotify/util/MessageUtil.java
@@ -367,6 +367,8 @@ public class MessageUtil {
 
         // Substitute capturing groups
         if (matcher != null && matcher.find(0)) {
+            // Convert message into a format suitable for recursive processing
+            msg = FormatUtil.convertToStyledLiteral(msg.copy());
 
             // Record indexes where groups should be placed,
             // and make Components for each group.
@@ -402,7 +404,6 @@ public class MessageUtil {
                 MutableComponent newMsg = Component.empty();
                 int startIndex = 0;
                 for (int[] replacement : indexesToReplaceWithGroups) {
-                    System.out.println(newMsg);
                     newMsg.append(Component.literal(
                             msgString.substring(startIndex, replacement[0])));
                     newMsg.append(replacementComponents.get(replacement[1]));

--- a/common/src/main/java/dev/terminalmc/chatnotify/util/StyleUtil.java
+++ b/common/src/main/java/dev/terminalmc/chatnotify/util/StyleUtil.java
@@ -214,6 +214,75 @@ public class StyleUtil {
     }
 
     /**
+     * Uses a recursive traversal algorithm to get a substring of a message
+     * with its original style.
+     * @param msg the message to get a substring of.
+     * @param start the starting index of the string to restyle.
+     * @param end the index after the end of the string to restyle.
+     * @return a substring of the message, with all of its original style.
+     */
+    public static Component substringKeepStyle(Component msg, int start, int end) {
+        return recursiveKeepStyle(msg.copy(), start, end, 0);
+    }
+
+    /**
+     * Recursive traversal algorithm to get a substring of a message with its original style.
+     *
+     * <p><b>Note:</b> Like {@link #recursiveRestyle(MutableComponent, TextStyle, int, int, int)} unable to process format codes or translatable
+     * components, but it differs in that {@link FormatUtil#convertToStyledLiteral} is used within method, so does not need to be done prior to
+     * invoking this method.</p>
+     *
+     * @param msg the message to get a substring of.
+     * @param start the root string index of the first character in the target substring.
+     * @param end the root string index of the last character in the target substring, plus one.
+     * @param index the index of the start of {@code msg} in the root string.
+     * @return a substring of the message, with all of its original style.
+     */
+    public static MutableComponent recursiveKeepStyle(MutableComponent msg,
+                                                   int start, int end, int index) {
+        if (debug) ChatNotify.LOG.warn("keepStyleForSubstring('{}', {}, {}, {})",
+                msg.getString(), start, end, index);
+
+        msg = FormatUtil.convertToStyledLiteral(msg);
+
+        // Detach siblings
+        List<Component> oldSiblings = new ArrayList<>(msg.getSiblings());
+        msg.getSiblings().clear();
+
+        // Add contents with original style.
+        if (msg.getContents() instanceof PlainTextContents contents) {
+            if (debug) ChatNotify.LOG.warn("PlainTextContents");
+            String str = contents.text();
+            if (index + str.length() >= start && index < end) {
+                // Target string overlaps with current substring,
+                // so add the included section with its original style
+                Style oldStyle = msg.getStyle();
+                msg = Component.empty().withStyle(oldStyle);
+
+                int localStart = Math.max(0, start - index);
+                int localEnd = Math.min(str.length(), end - index);
+
+                str = str.substring(localStart, localEnd);
+                msg.append(Component.literal(str));
+            }
+            index += str.length();
+        }
+
+        // Recurse for original siblings and re-attach
+        List<Component> siblings = msg.getSiblings();
+        for (Component sibling : oldSiblings) {
+            String str = sibling.getString();
+            if (index + str.length() >= start && index < end) {
+                siblings.add(recursiveKeepStyle(sibling.copy(), start, end, index));
+            }
+
+            index += str.length();
+        }
+
+        return msg;
+    }
+
+    /**
      * For each enabled field of the specified {@link TextStyle}, overrides the
      * corresponding {@link Style} field.
      * @param style the {@link Style} to apply to.

--- a/common/src/main/java/dev/terminalmc/chatnotify/util/StyleUtil.java
+++ b/common/src/main/java/dev/terminalmc/chatnotify/util/StyleUtil.java
@@ -228,8 +228,8 @@ public class StyleUtil {
     /**
      * Recursive traversal algorithm to get a substring of a message with its original style.
      *
-     * <p><b>Note:</b> Like {@link #recursiveRestyle(MutableComponent, TextStyle, int, int, int)} unable to process format codes or translatable
-     * components, but it differs in that {@link FormatUtil#convertToStyledLiteral} is used within method, so does not need to be done prior to
+     * <p><b>Note:</b> Unable to process format codes or translatable
+     * components, use {@link FormatUtil#convertToStyledLiteral} prior to
      * invoking this method.</p>
      *
      * @param msg the message to get a substring of.
@@ -242,8 +242,6 @@ public class StyleUtil {
                                                    int start, int end, int index) {
         if (debug) ChatNotify.LOG.warn("keepStyleForSubstring('{}', {}, {}, {})",
                 msg.getString(), start, end, index);
-
-        msg = FormatUtil.convertToStyledLiteral(msg);
 
         // Detach siblings
         List<Component> oldSiblings = new ArrayList<>(msg.getSiblings());


### PR DESCRIPTION
Was annoyed that captured regex groups didn't keep the styling of the original message.

Original message:
![image](https://github.com/user-attachments/assets/2d0be632-3d94-48f4-97bc-143d10c9e978)

Replacement message with captured group "(5)":
![image](https://github.com/user-attachments/assets/f3d643fc-5a84-40b9-97d3-ef34b7491622)

With my changes:
![image](https://github.com/user-attachments/assets/7534ea8c-b298-4f2f-8031-26ff6ad1f52e)


Added StyleUtil.recursiveKeepStyle and StyleUtil.substringKeepStyle to get a substring of a msg with its original style. Implemented StyleUtil.substringKeepStyle into MessageUtil.convertMsg to keep style of captured groups.

As a consequence styling is reset after each group (e.g. "$n test (5) test2" test2 will not be underlined. You would have to do "$n test (5)$n test2").

You also cannot restyle a captured group. It might be good to add more functionality for this, such as:
    - styling directly before a group applying to the group (e.g. "$n(5)").
    - "$" before a group ignoring the group's original styling, and reverting to previous behavior(e.g. "$n test $(5) test" would underline the whole message, and not keep any styling from the group).


My changes work for Replacement, Status bar, Title, and Toast messages.
Only tested with Fabric.

There is quite possibly a much better way to do what I did, but oh well.
Did my best to comment and include javadocs, though they may be inaccurate because I don't really fully understand Components and just built off of the StyleUtil.recursiveRestyle method and trial-and-errored my way to victory.

This is also my first pull request to anything, so tell me if I did something wrong.